### PR TITLE
feat: configure async sqlalchemy base

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,19 +1,31 @@
+from pathlib import Path
 from typing import List
-from pydantic import field_validator
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 def _split_ids(v: str | List[int] | None) -> List[int]:
     if v is None:
         return []
+    if isinstance(v, int):
+        return [v]
     if isinstance(v, list):
         return [int(x) for x in v]
     raw = v.replace(";", ",").replace(" ", ",")
     parts = [p.strip() for p in raw.split(",") if p.strip()]
     return [int(p) for p in parts]
 
+_ROOT_DIR = Path(__file__).resolve().parent.parent
+_DEFAULT_DB_PATH = (_ROOT_DIR / "database" / "bot.db").resolve()
+
+
 class Settings(BaseSettings):
     BOT_TOKEN: str
     ADMIN_IDS: List[int] = []
+    DATABASE_URL: str = Field(
+        default=f"sqlite+aiosqlite:///{_DEFAULT_DB_PATH.as_posix()}"
+    )
+    LOG_LEVEL: str = "INFO"
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -26,5 +38,21 @@ class Settings(BaseSettings):
     @classmethod
     def parse_admin_ids(cls, v):
         return _split_ids(v)
+
+    @property
+    def bot_token(self) -> str:
+        return self.BOT_TOKEN
+
+    @property
+    def admin_ids(self) -> List[int]:
+        return self.ADMIN_IDS
+
+    @property
+    def database_url(self) -> str:
+        return self.DATABASE_URL
+
+    @property
+    def log_level(self) -> str:
+        return self.LOG_LEVEL
 
 settings = Settings()

--- a/database/db.py
+++ b/database/db.py
@@ -1,68 +1,27 @@
-import sqlite3
-from pathlib import Path
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
 
-DB_PATH = Path(__file__).resolve().parent / "bot.db"
-
-
-def get_connection():
-    return sqlite3.connect(DB_PATH)
-
-
-# ==== Работа с администраторами ====
-def add_admin(user_id: int):
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS admins (user_id INTEGER PRIMARY KEY)"
-    )
-    cur.execute(
-        "INSERT OR IGNORE INTO admins (user_id) VALUES (?)", (user_id,)
-    )
-    conn.commit()
-    conn.close()
+from config.settings import settings
 
 
-def get_admins():
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute("CREATE TABLE IF NOT EXISTS admins (user_id INTEGER PRIMARY KEY)")
-    cur.execute("SELECT user_id FROM admins")
-    rows = cur.fetchall()
-    conn.close()
-    return [row[0] for row in rows]
+class Base(DeclarativeBase):
+    """Base declarative class for SQLAlchemy models."""
 
 
-# ==== Работа с заказами ====
-def add_order(item: str, status: str = "новый"):
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS orders (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            item TEXT,
-            status TEXT
-        )
-        """
-    )
-    cur.execute("INSERT INTO orders (item, status) VALUES (?, ?)", (item, status))
-    conn.commit()
-    conn.close()
+engine: AsyncEngine = create_async_engine(settings.database_url)
+async_session_factory = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
 
-
-def get_all_orders():
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS orders (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            item TEXT,
-            status TEXT
-        )
-        """
-    )
-    cur.execute("SELECT id, item, status FROM orders ORDER BY id DESC LIMIT 10")
-    rows = cur.fetchall()
-    conn.close()
-    return [{"id": r[0], "item": r[1], "status": r[2]} for r in rows]
+__all__ = [
+    "Base",
+    "engine",
+    "async_session_factory",
+]

--- a/database/migrate.py
+++ b/database/migrate.py
@@ -1,4 +1,10 @@
 import asyncio
+import sys
+from pathlib import Path
+
+if __package__ is None:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from database.db import engine, Base
 from database import models  # noqa
 

--- a/database/sqlite_utils.py
+++ b/database/sqlite_utils.py
@@ -1,0 +1,70 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "bot.db"
+
+
+def get_connection():
+    return sqlite3.connect(DB_PATH)
+
+
+# ==== Работа с администраторами ====
+
+def add_admin(user_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS admins (user_id INTEGER PRIMARY KEY)"
+    )
+    cur.execute(
+        "INSERT OR IGNORE INTO admins (user_id) VALUES (?)", (user_id,)
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_admins():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE IF NOT EXISTS admins (user_id INTEGER PRIMARY KEY)")
+    cur.execute("SELECT user_id FROM admins")
+    rows = cur.fetchall()
+    conn.close()
+    return [row[0] for row in rows]
+
+
+# ==== Работа с заказами ====
+
+def add_order(item: str, status: str = "новый"):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item TEXT,
+            status TEXT
+        )
+        """
+    )
+    cur.execute("INSERT INTO orders (item, status) VALUES (?, ?)", (item, status))
+    conn.commit()
+    conn.close()
+
+
+def get_all_orders():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item TEXT,
+            status TEXT
+        )
+        """
+    )
+    cur.execute("SELECT id, item, status FROM orders ORDER BY id DESC LIMIT 10")
+    rows = cur.fetchall()
+    conn.close()
+    return [{"id": r[0], "item": r[1], "status": r[2]} for r in rows]

--- a/utils/seed_admin.py
+++ b/utils/seed_admin.py
@@ -1,8 +1,8 @@
 from config.settings import settings
-from database import db
+from database.sqlite_utils import add_admin
 
 
 def add():
     for admin_id in settings.admin_ids:
-        db.add_admin(admin_id)
+        add_admin(admin_id)
     print("✅ Админы добавлены из settings.admin_ids")


### PR DESCRIPTION
## Summary
- add an async SQLAlchemy engine and declarative Base for the project database layer
- expose an async session factory and move legacy sqlite helpers to a separate module
- extend settings with database configuration helpers and allow the migration script to run standalone

## Testing
- python database/migrate.py

------
https://chatgpt.com/codex/tasks/task_e_68d036ff828c8325adbc671e44c9f692