### PR TITLE
Add status menu handler and align main menu usage

### DIFF
--- a/handlers/order.py
+++ b/handlers/order.py
@@ -4,6 +4,8 @@ from aiogram.types import Message, ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 
+from keyboards.main import main_menu
+
 router = Router()
 
 
@@ -15,14 +17,6 @@ class OrderFSM(StatesGroup):
 
 
 # === Клавиатуры ===
-main_menu_kb = ReplyKeyboardMarkup(
-    keyboard=[
-        [KeyboardButton(text="Новый заказ")],
-        [KeyboardButton(text="Статус заказа")],
-    ],
-    resize_keyboard=True
-)
-
 cancel_kb = ReplyKeyboardMarkup(
     keyboard=[
         [KeyboardButton(text="❌ Отмена")]
@@ -32,7 +26,7 @@ cancel_kb = ReplyKeyboardMarkup(
 
 
 # === Старт нового заказа ===
-@router.message(F.text == "Новый заказ")
+@router.message(F.text == "🆕 Новый заказ")
 async def start_order(message: Message, state: FSMContext):
     await state.set_state(OrderFSM.choosing_product)
     await message.answer(
@@ -73,7 +67,7 @@ async def confirm_order(message: Message, state: FSMContext):
         f"✅ Заказ принят!\n"
         f"📦 {data['product']}\n"
         f"🔢 {data['quantity']}",
-        reply_markup=main_menu_kb
+        reply_markup=main_menu()
     )
     await state.clear()
 
@@ -82,4 +76,4 @@ async def confirm_order(message: Message, state: FSMContext):
 @router.message(F.text.lower().contains("отмена"))
 async def cancel_order(message: Message, state: FSMContext):
     await state.clear()
-    await message.answer("❌ Заказ отменён", reply_markup=main_menu_kb)
+    await message.answer("❌ Заказ отменён", reply_markup=main_menu())

--- a/handlers/status.py
+++ b/handlers/status.py
@@ -1,8 +1,19 @@
-from aiogram import Router, types
+from aiogram import Router, types, F
 from aiogram.filters import Command
+
 
 router = Router()
 
+
+async def _reply_with_status(message: types.Message) -> None:
+    await message.answer("Проверка статуса заказа (заглушка)")
+
+
 @router.message(Command("status"))
 async def status_handler(message: types.Message):
-    await message.answer("Проверка статуса заказа (заглушка)")
+    await _reply_with_status(message)
+
+
+@router.message(F.text.in_({"Статус заказа", "📦 Статус заказа"}))
+async def status_text_handler(message: types.Message):
+    await _reply_with_status(message)

--- a/handlers/welcome.py
+++ b/handlers/welcome.py
@@ -1,7 +1,10 @@
 from aiogram import Router, types
 from aiogram.filters import Command
 
+from keyboards.main import main_menu
+
 router = Router()
+
 
 @router.message(Command("start"))
 async def welcome_handler(message: types.Message):
@@ -10,5 +13,6 @@ async def welcome_handler(message: types.Message):
         "Доступные команды:\n"
         "- /order — новый заказ\n"
         "- /status — статус заказа\n"
-        "- /admin — админ-панель"
+        "- /admin — админ-панель",
+        reply_markup=main_menu()
     )


### PR DESCRIPTION
## Summary
- add a text-based status handler that reuses the command logic
- align order flow buttons with the emoji-labelled main menu and reuse the shared keyboard
- show the unified main menu keyboard from the welcome message

## Testing
- python -m compileall handlers keyboards

------
https://chatgpt.com/codex/tasks/task_e_68d7ecfb8dfc8325ba8e495e5fa9eff1